### PR TITLE
feat(function): add `bindArgs`

### DIFF
--- a/src/function.spec.ts
+++ b/src/function.spec.ts
@@ -1,6 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Mock,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
-import { callAll, noop, not, sleep } from './function';
+import { callAll, noop, not, sleep, bindArgs } from './function';
 
 describe('function', () => {
   describe('noop', () => {
@@ -71,6 +80,30 @@ describe('function', () => {
       vi.advanceTimersByTime(1000);
 
       expect(v).resolves.toBe(undefined);
+    });
+  });
+
+  describe('bindArgs', () => {
+    const mockedFn = vi.fn(
+      (prefix: 'prefix', message: 'message', count: 1 | 2): 'fail' | 'ok' => {
+        [prefix, message, count].join('-');
+        return count === 1 ? 'ok' : 'fail';
+      },
+    );
+
+    let boundFn: (...args: any) => any;
+
+    beforeEach(() => {
+      boundFn = bindArgs(mockedFn as any, 'prefix');
+    });
+
+    it('should return bound function', () => {
+      expect(boundFn).toBeTypeOf('function');
+    });
+
+    it('should bind given function with an rest args', () => {
+      expect(boundFn('message', 1)).toEqual('ok');
+      expect(boundFn('message', 2)).toEqual('fail');
     });
   });
 });

--- a/src/function.ts
+++ b/src/function.ts
@@ -51,3 +51,18 @@ export const sleep = (ms: number): Promise<void> =>
   new Promise<void>(resolve => {
     setTimeout(() => resolve(), ms);
   });
+
+/**
+ * @param {Function} target function to bind to itself and arguments
+ * @param {...Partial<args>} part_args the arguments should be bind to target
+ * @return {Function} bounded target with arguments
+ */
+export const bindArgs = <
+  TFn extends (...args: any) => any,
+  TArgs extends Parameters<TFn> = Parameters<TFn>,
+>(
+  fn: TFn,
+  ...args: [...Partial<[...TArgs]>]
+): ((...args: any) => ReturnType<TFn>) => {
+  return fn.bind(fn, ...(args as unknown[]));
+};


### PR DESCRIPTION
ref-to: #58 issue

to bind only arguments without `this` argument

include:
- implement (partial)
- tests  (partial)
- JSDoc (partial)