### PR TITLE
Add `mod` function

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -880,6 +880,7 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
       "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1226,6 +1227,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001503",
         "electron-to-chromium": "^1.4.431",
@@ -1623,6 +1625,7 @@
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.25.0.tgz",
       "integrity": "sha512-7MW3Iz57mCUo6JQCho6CmPBCbTlJr7LzyEtIkutG255HLVd4XuBg2I9BkTZLI/e4HoaOB/BiAzXuQybQ95+r9Q==",
+      "peer": true,
       "dependencies": {
         "heap": "^0.2.6",
         "lodash": "^4.17.21"
@@ -1966,6 +1969,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2360,6 +2364,7 @@
       "version": "8.43.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
       "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -2536,6 +2541,7 @@
       "version": "2.27.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -5427,6 +5433,7 @@
       "version": "13.4.7",
       "resolved": "https://registry.npmjs.org/next/-/next-13.4.7.tgz",
       "integrity": "sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==",
+      "peer": true,
       "dependencies": {
         "@next/env": "13.4.7",
         "@swc/helpers": "0.5.1",
@@ -5539,6 +5546,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nextra/-/nextra-2.8.0.tgz",
       "integrity": "sha512-WyRNzw1IM/eF3M1H3LSsbZH97QsYYgj8upjx0f8hY6GspmPyPRAvBBscmXRt+7vye2oIYjfVwSiD1rj9amqq9Q==",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^2.3.0",
         "@mdx-js/react": "^2.3.0",
@@ -6005,6 +6013,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -6179,6 +6188,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6190,6 +6200,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6673,6 +6684,7 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
       "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "peer": true,
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -7306,6 +7318,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
       "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/docs/pages/number/_meta.json
+++ b/docs/pages/number/_meta.json
@@ -7,6 +7,7 @@
   "is-in-range": "isInRange",
   "is-negative": "isNegative",
   "is-positive": "isPositive",
+  "mod": "mod",
   "percent": "percent",
   "random-int": "randomInt",
   "to-decimal": "toDecimal"

--- a/docs/pages/number/mod.mdx
+++ b/docs/pages/number/mod.mdx
@@ -1,0 +1,27 @@
+# mod
+
+Returns the modulo of value in the range [0, divisor). Unlike JavaScript's % operator, the result is always non-negative (assuming divisor is positive).
+
+### Import
+
+```ts copy
+import { mod } from '@fullstacksjs/toolbox';
+```
+
+### Signature
+
+```ts copy
+function mod(value: number, divisor: number): number {}
+```
+
+### Examples
+
+```ts copy
+mod(10, 10)  // 0
+mod(11, 10)  // 1
+mod(20, 10)  // 0
+mod(-1, 10)  // 9
+mod(-9, 10)  // 1
+mod(-10, 10) // 0
+mod(-11, 10) // 9
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,10 +1235,33 @@
         "node": ">=20"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2827,6 +2850,17 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {

--- a/src/number/mod.spec.ts
+++ b/src/number/mod.spec.ts
@@ -1,0 +1,28 @@
+import { mod } from './mod.ts';
+
+describe('mod', () => {
+  it.each([
+    { value: 10, divisor: 10, expected: 0 },
+    { value: 11, divisor: 10, expected: 1 },
+    { value: 20, divisor: 10, expected: 0 },
+    { value: -1, divisor: 10, expected: 9 },
+    { value: -9, divisor: 10, expected: 1 },
+    { value: -10, divisor: 10, expected: 0 },
+    { value: -11, divisor: 10, expected: 9 },
+  ])('$value mod $divisor = $expected', ({ value, divisor, expected }) => {
+    expect(mod(value, divisor)).toBe(expected);
+  });
+
+  it.each([
+    { value: NaN, divisor: 10 },
+    { value: 10, divisor: NaN },
+    { value: NaN, divisor: NaN },
+  ])('$value mod $divisor = NaN', ({ value, divisor }) => {
+    expect(mod(value, divisor)).toBeNaN();
+  });
+
+  it('should throw an error if the divisor is less than or equal to 0', () => {
+    expect(() => mod(10, 0)).toThrow('Divisor must be greater than 0');
+    expect(() => mod(10, -1)).toThrow('Divisor must be greater than 0');
+  });
+});

--- a/src/number/mod.ts
+++ b/src/number/mod.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns the positive modulo of a number.
+ *
+ * Unlike JavaScript's `%` operator, this function always returns a value in
+ * the range `[0, divisor)` when `divisor` is positive.
+ *
+ * @param value - The value to wrap.
+ * @param divisor - The positive divisor (modulus).
+ * @returns The positive modulo of `value`.
+ *
+ * @example
+ * mod(10, 10) // 0
+ * mod(11, 10) // 1
+ * mod(-1, 10) // 9
+ */
+export function mod(value: number, divisor: number): number {
+  if (divisor <= 0) {
+    throw new RangeError('Divisor must be greater than 0');
+  }
+  return ((value % divisor) + divisor) % divisor;
+}


### PR DESCRIPTION
Adds a `mod()` utility for computing the non-negative modulo of a number.

Unlike JavaScript's `%` operator, which returns the remainder and can produce negative results, `mod()` always returns a value in the range `[0, divisor)` for a positive divisor. This makes it useful for wrapping indices, cyclic counters, and other modular arithmetic.

### Examples

```ts
mod(10, 10); // 0
mod(11, 10); // 1
mod(-1, 10); // 9
```

### Tests

Adds unit tests covering:

* Positive values
* Negative values
* Exact multiples of the divisor
* `NaN` inputs
